### PR TITLE
Removed wikipedia image from the Google Graph

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -44,7 +44,7 @@
       "@type": "WebSite",
       "name": "Sugar Labs",
       "url": "http://plus.google.com/111673993478233827739/",
-      "logo": "https://en.wikipedia.org/wiki/File:Sugarlabs-logo.png",
+      "logo": "https://sugarlabs.org/assets/home-screenshot.png",
       "description": "Sugar Labs is creator of the award-winning Sugar Learning Platform, which promotes collaborative learning through Sugar Activities.",
       "publisher": "http://plus.google.com/111673993478233827739" 
     }


### PR DESCRIPTION
Google doesn't work with Wikipedia image, so i uploaded our own image instead