### PR TITLE
Removed link placed in `head` section what caused an error to appear

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -37,7 +37,6 @@
     <meta property="og:image" content="https://sugarlabs.org/assets/home-screenshot.png" />
 
     <!-- Knowledge graph card generated from Google Plus -->
-    <a href="http://plus.google.com/111673993478233827739" ref="publisher">
     <script type='application/ld+json'> 
     {
       "@context": "http://www.schema.org",


### PR DESCRIPTION
`<a>` tag is forbidden in `<head>` by HTML rules.