### PR TITLE
Update installation instructions to use bundle exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Redesigned version of "www.sugarlabs.org"
 
 ## Introduction
-This repository contains the code for the redesigned version of "www.sugarlabs.org". This repository code base was used for the development of the GSOC 2017 project **Giving Sugar Labs Website a New Look** under the organization **Sugar Labs**. The changes made during the **GSOC** period can be viewed at [https://github.com/sugarlabs/www-sugarlabs/issues/63](https://github.com/sugarlabs/www-sugarlabs/issues/63). The repository of the original website is located at [https://github.com/sugarlabs/www-sugarlabs](https://github.com/sugarlabs/www-sugarlabs). The work during **GSOC** was done in the repository [https://github.com/geekrypter/sugarLabsWebsiteRedesign](https://github.com/geekrypter/sugarLabsWebsiteRedesign). A live preview of the website is hosted using **Github pages** and can be viewed at [https://geekrypter.github.io/sugarLabsWebsiteRedesign/](https://geekrypter.github.io/sugarLabsWebsiteRedesign/). The code uses the same Jekyll environment as that of the original website's code. Do check out the code! 
+This repository contains the code for the redesigned version of "www.sugarlabs.org". This repository code base was used for the development of the GSOC 2017 project **Giving Sugar Labs Website a New Look** under the organization **Sugar Labs**. The changes made during the **GSOC** period can be viewed at [https://github.com/sugarlabs/www-sugarlabs/issues/63](https://github.com/sugarlabs/www-sugarlabs/issues/63). The repository of the original website is located at [https://github.com/sugarlabs/www-sugarlabs](https://github.com/sugarlabs/www-sugarlabs). The work during **GSOC** was done in the repository [https://github.com/geekrypter/sugarLabsWebsiteRedesign](https://github.com/geekrypter/sugarLabsWebsiteRedesign). A live preview of the website is hosted using **Github pages** and can be viewed at [https://geekrypter.github.io/sugarLabsWebsiteRedesign/](https://geekrypter.github.io/sugarLabsWebsiteRedesign/). The code uses the same Jekyll environment as that of the original website's code. Do check out the code!
 
 ### Major Services
 We have integrated 4 major features with the help of third party services:
@@ -34,7 +34,7 @@ Install Ruby and the Gem package manager (pre-installed in Mac OS X) and install
 ### Running
 Jekyll can run a local web server that rebuilds each time you save a page while editing (Execute the below command from root directory):
 
-    jekyll serve --incremental;
+    bundle exec jekyll serve --incremental;
 
 Then open [http://localhost:4000](http://localhost:4000)
 ### Note
@@ -50,4 +50,3 @@ If some changes are not visible (after saving a page while editing), please rest
 6. Be careful when changing the cache control code present in the **.htaccess** file.
 7. Whenever the dependency/library versions are changed, please update the local files of those dependencies as these local files are referenced when the cdn does not work.
 8. The current website uses customized versions of few social media icons (service provided by [Social Share Kit](http://socialsharekit.com)). So we use the local files of the service and do our customizations in the css file of the service (**/assets/dist/css/social-share-kit.css** file in our case). Please be careful when updating the files of this service. (Also refer to **How to change social media icon colors?** subsection in **Answers to few questions** section)
-


### PR DESCRIPTION
Not using `bundle exec` to serve the website could cause versioning errors, and using `bundle exec` is recommended by Jekyll. 

This should hopefully save some people new to Jekyll and the gem package manager some debugging time!