### PR TITLE
Fixes broken links in about-us.html

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -180,11 +180,8 @@ permalink: /about-us/index.html
                             <h2>Projects</h2>
                             <p class="customParagraphStyle">Sugar Labs is working on a few <a href="https://wiki.sugarlabs.org/go/Category:Project" class="hrefCustomColor">projects</a> focused on delivering specific goals in a defined time period. The "Projects" panel in the Sugar Labs wiki sidebar holds our premier projects. Please also see these project home pages:
                             <ul>
-                                <li><a href="https://wiki.sugarlabs.org/go/Harmonic_Distribution" class="hrefCustomColor">Harmonic Distribution</a></li>
-                                <li><a href="https://sugardextrose.org" class="hrefCustomColor">Dextrose</a></li> 
                                 <li><a href="https://wiki.sugarlabs.org/go/Sugar_Creation_Kit" class="hrefCustomColor">Sugar Creation Kit</a></li>
                                 <li><a href="https://wiki.sugarlabs.org/go/Sugar_on_a_Stick" class="hrefCustomColor">Sugar on a Stick</a></li>
-                                <li><a href="https://wiki.sugarlabs.org/go/Replacing_Textbooks" class="hrefCustomColor">Replacing Textbooks</a></li>
                                 <li><a href="https://wiki.sugarlabs.org/go/Math4Team" class="hrefCustomColor">Math4 Project</a></li>
                                 <li><a href="https://wiki.sugarlabs.org/go/Summer_of_Code" class="hrefCustomColor">Summer of Code</a></li>
                             </ul>


### PR DESCRIPTION
Fixes #114 and #115 
Removed Dextrose, "Harmonic distribution" and "Replacing Textbooks" hyperlinks from about-us.html 

@quozl please review.