### PR TITLE
suggested security update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       listen (= 3.0.6)
       mercenary (~> 0.3)
       minima (= 2.0.0)
-      nokogiri (= 1.6.8.1)
+      nokogiri (-> 1.8.1)
       rouge (= 1.11.1)
       terminal-table (~> 1.4)
     github-pages-health-check (1.3.3)


### PR DESCRIPTION
There is a vulnerability reported in nokogiri and it is recommended to update to v 1.8.1

Gemfile.lock has been updated to:
nokogiri ~> 1.8.1

Not 100% sure how to test this.