### PR TITLE
Remove out-of-date PR contact information

### DIFF
--- a/press.html
+++ b/press.html
@@ -34,10 +34,12 @@ permalink: /press/index.html
                             <h2 class="text-center" >Contacts & Resources</h2>
                             <hr>
                             <ul>
+                                <!-- 
                                 <li class="listFont"><i class="icon ion-ios-person"></i>&nbsp;&nbsp;&nbsp;Sean Daly</li>
                                 <li class="listFont"><i class="icon ion-ios-people"></i>&nbsp;&nbsp;Marketing Coordinator</li>
-                                <li class="listFont"><i class="icon ion-android-mail"></i>&nbsp;&nbsp;<a href="mailto:pr@sugarlabs.org">pr@sugarlabs.org</a></li>
                                 <li class="listFont"><i class="icon ion-ios-telephone"></i>&nbsp;&nbsp;<a href="tel:+1-617-500-9610">+1 (617) 500-9610</a></li>
+                                -->
+                                <li class="listFont"><i class="icon ion-android-mail"></i>&nbsp;&nbsp;<a href="mailto:pr@sugarlabs.org">pr@sugarlabs.org</a></li>
                                 <li class="listFont"><address><i class="icon ion-ios-home"></i>&nbsp;&nbsp;Sugar Labs<br/>
                                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c/o Software Freedom Conservancy<br/>
                                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;137 Montague Street, Suite 380<br/>


### PR DESCRIPTION
As per Sean Daly's direct request, he would like his contact information removed from the Sugar Labs Press page, as he is no longer the PR contact. This is documented at http://lists.sugarlabs.org/archive/marketing/2018-March/thread.html