### PR TITLE
Remove decrepit Press Resources link from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -73,7 +73,6 @@
                         <article class="widget_content">
                             <ul class="leftAlign align-center-col-md">
                                 <li class="footerListStyle"><a href="{{ site.baseurl }}/more" >Culture and pedagogy</a></li>
-                                <li class="footerListStyle"><a href="{{ site.baseurl }}/press" >Press Resources</a></li>
                                 <li class="footerListStyle"><a href="http://schoolserver.org/" >School Server Resources</a></li>
                                 <li class="footerListStyle"><a href="http://planet.sugarlabs.org" >Planet Sugar Labs</a></li>
                                 <li class="footerListStyle"><a href="{{ site.baseurl }}/about-libre-software-culture" >Libre Software Culture</a></li>


### PR DESCRIPTION
As per discussion with SLOBs, this will be removed for now (no SLOB disagreement), and will likely stay that way unless someone volunteers to keep it current, and/or is officially appointed as marketing overseer.