### PR TITLE
fixed footer cursor

### DIFF
--- a/css/airspace.css
+++ b/css/airspace.css
@@ -913,7 +913,6 @@ footer .footer-manu ul li a:hover {
 }
 
 .widget h4 {
- cursor:pointer;
  padding-bottom:5px;
 }
 


### PR DESCRIPTION
in reference to #145  which was partially fixed, now it has been fixed completely and the cursor is not activated on hovering over titles which are not linked to anything.