### PR TITLE
space between the icon and gitHub link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -123,7 +123,7 @@
                                 </br>
                                 <div class="row">
                                     <div id="contributeHeader" class="col-md-12">
-                                        <h4 class='align-center-md'><a href="https://github.com/sugarlabs/www-sugarlabs"><b><span class="ion-social-github" style="font-size:17px;color: #0099FF;"></span><span style="font-size:17px;color: #0099FF;">Contribute to website</span></b></a></h4>
+                                        <h4 class='align-center-md'><a href="https://github.com/sugarlabs/www-sugarlabs"><b><span class="ion-social-github" style="font-size:17px;color: #0099FF; margin-right: 12px;"></span><span style="font-size:17px;color: #0099FF;">Contribute to website</span></b></a></h4>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
fix #74 