### PR TITLE
Match button and email width, make button consistent with Bootstrap

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-+<!-- Chat button for screens with width <= 991px -->
+<!-- Chat button for screens with width <= 991px -->
 <button id="myBtn2" title="IRC chat" data-toggle="modal" data-target="#fsModal"><span class="ion-ios-chatbubble" style="font-size:22px;"></span></button>
 
 <!-- Chat window for screens with width <= 991px -->

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<!-- Chat button for screens with width <= 991px -->
++<!-- Chat button for screens with width <= 991px -->
 <button id="myBtn2" title="IRC chat" data-toggle="modal" data-target="#fsModal"><span class="ion-ios-chatbubble" style="font-size:22px;"></span></button>
 
 <!-- Chat window for screens with width <= 991px -->
@@ -106,13 +106,13 @@
                                                 <div id="mc_embed_signup_scroll">
                                                     <label class='align-center-md' for="mce-EMAIL"><h4><span class="customSpanColor"><b>Subscribe to our newsletter</b></span></h4></label>
                                                     <div class='align-center-md'>
-                                                        <input type="email" value="" name="EMAIL" class="email footer-email-input-md" id="mce-EMAIL" placeholder="email address" required>
+                                                        <input type="email" value="" name="EMAIL" class="email footer-email-input-md" id="mce-EMAIL" placeholder="email address" required style="width: 70%;">
                                                     </div>
                                                     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
                                                     <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_23c6df6118693ee743df3e0a4_11cb7e5c96" tabindex="-1" value=""></div>
                                                     <div class="clear">
                                                         <div class='align-center-md'>
-                                                            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
+                                                            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-custom" style="width: 70%;">
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
Fixes #181.
For the email subscribe area, I made the button and input the same width, and changed the button from using Mailchimp styling to the Bootstrap styling.
![Screenshot of fixed button](https://i.imgur.com/SBD3N6G.png)

_Note_ Add class _bt_ to the button to make the button rectangular like the other ones. I chose not to do this, as the heights would be different and look strange