### PR TITLE
Remove Sugar Labs Embedded Youtube Video

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,6 @@ title: Sugar Labs
                             <p class="customColor">Sugar is a learning platform that reinvents how computers are used for education. Collaboration, reflection, and discovery are integrated directly into the user interface. Sugar promotes "studio thinking" and "reflective practice". Through Sugar's clarity of design, children and teachers have the opportunity to use computers on their own terms. Students can reshape, reinvent, and reapply both software and content into powerful learning activities. Sugar's focus on sharing, criticism, and exploration is grounded in the culture of free software (FLOSS).</p>
                         </div>
                     </div>
-                    <div class="col-md-5 col-md-push-1">
-                        <div class="block">
-                            <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/b8-7RlfP7MA?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
-                        </div>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This video is not of sufficient quality to be prominently displayed on the landing page of sugarlabs.org. The quality of the voiceover work is also very poor, and nearly uninteligible at many points.