### PR TITLE
remove non-existent IRC channels and re-order list

### DIFF
--- a/about-irc.html
+++ b/about-irc.html
@@ -83,29 +83,20 @@ permalink: /about-irc/index.html
                         <h2>SUGAR LABS IRC CHANNELS</h2>
                         <p class="customFontSize">Sugar Labs encourages communication through IRC. We have a long list of IRC channels and you can check them below.
                             <ul>
+                                <li>#sugar</li>       
+                                <li>#sugar-meeting, #sugar-meeting-es</li>        
+                                <li>#sugar-newbies, #sugar-newbies-es</li>    
+                                <li>#fedora-olpc</li>     
+                                <li>#ubuntu-sugarteam</li>
+                                <li>#supybot, #supybot-bots</li>
                                 <li>#aslo-dev</li>              
                                 <li>#etoys</li>        
-                                <li>#fedora-olpc</li>     
-                                <li>#gitenberg</li>    
-                                <li>#meeting</li>    
-                                <li>#meeting-test</li>         
-                                <li>#ole</li>         
+                                <li>#gitenberg</li>   
                                 <li>#olpc-aprendizaje-en</li>          
                                 <li>#olpc-help</li>       
                                 <li>#olpc-it</li>        
                                 <li>#olpc-meeting</li>       
                                 <li>#olpc-paraguay</li>
-                                <li>#olpc-sur</li>    
-                                <li>#publiclab</li>     
-                                <li>#sugar</li>       
-                                <li>#sugar-meeting</li>       
-                                <li>#sugar-meeting-es</li>        
-                                <li>#sugar-newbies</li>        
-                                <li>#sugar-newbies-es</li>    
-                                <li>#supybot</li>
-                                <li>#supybot-bots</li>
-                                <li>#ubuntu-sugarteam</li>
-                                <li>#ubuntu-us-dc</li>  
                             </ul>
                         </p>
                     </div>


### PR DESCRIPTION
There are a number of listed IRC channels here, some of which were wrong, some of which no longer exist, and have not for many, many moons. This is a first attempt at culling the list, and grouping the channels