### PR TITLE
Updated links to point to Music Blocks and Turtle Blocks repos

### DIFF
--- a/music-blocks.html
+++ b/music-blocks.html
@@ -63,7 +63,7 @@ permalink: /music-blocks/index.html
                     <div class="col-md-8 col-md-push-2" >    
                         <div class="section-title text-center">
                             <h2>USING MUSIC BLOCKS</h2>
-                            <p class="customParagraphStyle">Music Blocks is designed to run in the browser. It is derived from Turtle Blocks JS which can be found <a href="https://github.com/sugarlabs/turtleblocksjs" class="hrefCustomColor">here</a>. You can run the software locally from the index.html file, from the <a href="http://sugarlabs.github.io/musicblocks/" class="hrefCustomColor">github</a> repo, or by setting up a local server.</p>
+                            <p class="customParagraphStyle">Music Blocks is designed to run in the browser. It is derived from Turtle Blocks JS which can be found <a href="https://github.com/sugarlabs/turtleblocksjs" class="hrefCustomColor">here</a>. You can run the software locally from the index.html file, from the <a href="http://musicblocks.sugarlabs.org" class="hrefCustomColor">github</a> repo, or by setting up a local server.</p>
                             <p class="customParagraphStyle">If you want to run Music Blocks offline, download this repo and point your browser to the index.html file found in the musicblocks directory on your local file system.</p>
                             <p class="customParagraphStyle">See <a href="http://github.com/sugarlabs/musicblocks/tree/master/documentation" class="hrefCustomColor">Using Music Blocks</a> and <a href="http://github.com/sugarlabs/musicblocks/tree/master/guide" class="hrefCustomColor">Music Blocks Guide</a></p>
                         </div>

--- a/music-blocks.html
+++ b/music-blocks.html
@@ -86,7 +86,7 @@ permalink: /music-blocks/index.html
                         <br>
                         <p class="customFontSize">Devin Ulibarri has contributed functional and user-interface designs. Many of his contributions were inspired by the music education ideas, representations and practices (e.g. aspects of matrix, musical cups) developed and published by Dr. Lawrence Scripp with whom Devin studied at New England Conservatory and for whom he worked at Affron Scripp & Associates, LLC.</p>
                         <br>
-                        <p class="customFontSize"><a href="http://www.larryscripp.net/" class="hrefCustomColor">Larry Scripp</a></p>
+                        <p class="customFontSize"><a href="https://necmusic.edu/faculty/larry-scripp" class="hrefCustomColor">Larry Scripp</a></p>
                         <br>
                         <p class="customFontSize"><a href="http://centerformie.org/" class="hrefCustomColor">Center for Music and the Arts in Education (CMAIE)</a></p>
                         <br>

--- a/music-blocks.html
+++ b/music-blocks.html
@@ -63,9 +63,9 @@ permalink: /music-blocks/index.html
                     <div class="col-md-8 col-md-push-2" >    
                         <div class="section-title text-center">
                             <h2>USING MUSIC BLOCKS</h2>
-                            <p class="customParagraphStyle">Music Blocks is designed to run in the browser. It is derived from Turtle Blocks JS which can be found <a href="https://github.com/walterbender/turtleblocksjs" class="hrefCustomColor">here</a>. You can run the software locally from the index.html file, from the <a href="http://walterbender.github.io/musicblocks/" class="hrefCustomColor">github</a> repo, or by setting up a local server.</p>
+                            <p class="customParagraphStyle">Music Blocks is designed to run in the browser. It is derived from Turtle Blocks JS which can be found <a href="https://github.com/sugarlabs/turtleblocksjs" class="hrefCustomColor">here</a>. You can run the software locally from the index.html file, from the <a href="http://sugarlabs.github.io/musicblocks/" class="hrefCustomColor">github</a> repo, or by setting up a local server.</p>
                             <p class="customParagraphStyle">If you want to run Music Blocks offline, download this repo and point your browser to the index.html file found in the musicblocks directory on your local file system.</p>
-                            <p class="customParagraphStyle">See <a href="http://github.com/walterbender/musicblocks/tree/master/documentation" class="hrefCustomColor">Using Music Blocks</a> and <a href="http://github.com/walterbender/musicblocks/tree/master/guide" class="hrefCustomColor">Music Blocks Guide</a></p>
+                            <p class="customParagraphStyle">See <a href="http://github.com/sugarlabs/musicblocks/tree/master/documentation" class="hrefCustomColor">Using Music Blocks</a> and <a href="http://github.com/sugarlabs/musicblocks/tree/master/guide" class="hrefCustomColor">Music Blocks Guide</a></p>
                         </div>
                     </div>
                 </div>
@@ -82,7 +82,7 @@ permalink: /music-blocks/index.html
                 <div class="row">
                     <div class="col-md-8 col-md-push-2" >
                         <h2>CREDITS</h2>
-                        <p class="customFontSize">Music Blocks is a fork of TurtleArtJS created by Walter Bender. (Turtle Blocks JS has many <a href="https://github.com/walterbender/turtleblocksjs/graphs/contributors" class="hrefCustomColor">contributors</a>).</p>
+                        <p class="customFontSize">Music Blocks is a fork of TurtleArtJS created by Walter Bender. (Turtle Blocks JS has many <a href="https://github.com/sugarlabs/turtleblocksjs/graphs/contributors" class="hrefCustomColor">contributors</a>).</p>
                         <br>
                         <p class="customFontSize">Devin Ulibarri has contributed functional and user-interface designs. Many of his contributions were inspired by the music education ideas, representations and practices (e.g. aspects of matrix, musical cups) developed and published by Dr. Lawrence Scripp with whom Devin studied at New England Conservatory and for whom he worked at Affron Scripp & Associates, LLC.</p>
                         <br>
@@ -94,9 +94,9 @@ permalink: /music-blocks/index.html
                         <br>
                         <p class="customFontSize">Some of the graphics were contributed by Chie Yasuda.</p>
                         <br>
-                        <p class="customFontSize">Much of the initial coding of the fork from Turtle Blocks was done by Yash Khandelwal as part of Google Summer of Code (GSoC) 2015. Hemant Kasat contributed to additional widgets as part of GSoC 2016. Additional contributions are being made by Tayba Wasim, Dinuka Tharangi Jayaweera, Prachi Agrawal, Cristina Del Puerto, and Hrishi Patel as part of GSoC 2017.</p>
+                        <p class="customFontSize">Much of the initial coding of the fork from Turtle Blocks was done by Yash Khandelwal as part of Google Summer of Code (GSoC) 2015. Hemant Kasat contributed to additional widgets as part of GSoC 2016. Additional contributions are being made by Tayba Wasim, Dinuka Tharangi Jayaweera, Prachi Agrawal, Cristina Del Puerto, and Hrishi Patel as part of GSoC 2017. During GSoC 2018, Riya Lohia developed a Temperament Widget. Ritwik Abhishek added a keyboard widget and a pitch-tracking widget.</p>
                         <br>
-                        <p class="customFontSize">Many students contributed to the project as part of Google Code-in (2015-16 and 2016-17).</p>
+                        <p class="customFontSize">Many students contributed to the project as part of Google Code-in (2015–16, 2016–17, and 2017–2018). Sam Parkinson built the Planet during GCI 2016–17. Euan Ong redesigned the Planet code as a series of GCI tasks in 2017–18.</p>
                         <br>
                     </div>
                 </div>
@@ -113,7 +113,7 @@ permalink: /music-blocks/index.html
                 <div class="row">
                     <div class="col-md-8 col-md-push-2" >
                         <h2 class="text-center">REPORTING BUGS</h2>
-                        <p class="customParagraphStyle">Bugs can be reported in the <a href="https://bugs.sugarlabs.org/newticket?component=Turtleart" class="hrefCustomColor">Sugar Labs bug tracker</a> or in the <a href="https://github.com/walterbender/musicblocks/issues" class="hrefCustomColor">issues section</a> of this repository.</p>
+                        <p class="customParagraphStyle">Bugs can be reported in the <a href="https://bugs.sugarlabs.org/newticket?component=Turtleart" class="hrefCustomColor">Sugar Labs bug tracker</a> or in the <a href="https://github.com/sugarlabs/musicblocks/issues" class="hrefCustomColor">issues section</a> of this repository.</p>
                     </div>
                 </div>
             </div>

--- a/turtle-blocks-js.html
+++ b/turtle-blocks-js.html
@@ -60,7 +60,7 @@ permalink: /turtle-blocks-js/index.html
                     <div class="col-md-8 col-md-push-2" >
                         <div class="section-title text-center">
                             <h2>USING TURTLE ART JS</h2> 
-                            <p class="customParagraphStyle">Turtle Blocks Javascript is designed to run in a browser. Most of the development has been done in Chrome, but it should also work in Firefox. You can run it directly from index.html, from a <a href="http://turtle.sugarlabs.org/" class="hrefCustomColor">server maintained by Sugar Labs</a>, from the <a href="http://rawgit.com/walterbender/turtleblocksjs/master/index.html" class="hrefCustomColor">github repo</a>, or by setting up a <a href="https://github.com/walterbender/turtleblocksjs/blob/master/server.md" class="hrefCustomColor">local server</a>.</p>
+                            <p class="customParagraphStyle">Turtle Blocks Javascript is designed to run in a browser. Most of the development has been done in Chrome, but it should also work in Firefox. You can run it directly from index.html, from a <a href="http://turtle.sugarlabs.org/" class="hrefCustomColor">server maintained by Sugar Labs</a>, from the <a href="http://rawgit.com/sugarlabs/turtleblocksjs/master/index.html" class="hrefCustomColor">github repo</a>, or by setting up a <a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/server.md" class="hrefCustomColor">local server</a>.</p>
                             <p class="customParagraphStyle">Once you've launched it in your browser, start by clicking on (or dragging) blocks from the Turtle palette. Use multiple blocks to create drawings; as the turtle moves under your control, colorful lines are drawn.</p>
                             <p class="customParagraphStyle">You add blocks to your program by clicking on or dragging them from the palette to the main area. You can delete a block by dragging it back onto the palette. Click anywhere on a "stack" of blocks to start executing that stack or by clicking in the Rabbit (fast) or Turtle (slow) on the Main Toolbar.</p>
                         </div>
@@ -79,9 +79,9 @@ permalink: /turtle-blocks-js/index.html
                 <div class="row">
                     <div class="col-md-8 col-md-push-2" >
                         <h2>GETTING STARTED DOCUMENTATION</h2>
-                        <p class="customFontSize">The basic buttons and basic blocks are explained in detail in <a href="https://github.com/walterbender/turtleblocksjs/blob/master/documentation/README.md" class="hrefCustomColor">Documentation</a>.</p>
+                        <p class="customFontSize">The basic buttons and basic blocks are explained in detail in <a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/documentation/README.md" class="hrefCustomColor">Documentation</a>.</p>
                         <br>
-                        <p class="customFontSize">A guide to programming with Turtle Blocks is available in <a href="https://github.com/walterbender/turtleblocksjs/blob/master/guide/README.md" class="hrefCustomColor">Turtle Blocks Guide</a>.</p>
+                        <p class="customFontSize">A guide to programming with Turtle Blocks is available in <a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/guide/README.md" class="hrefCustomColor">Turtle Blocks Guide</a>.</p>
                         <br>
                         <p class="customFontSize"><b>A quick start:</b></p>
                         <br>
@@ -102,7 +102,7 @@ permalink: /turtle-blocks-js/index.html
                 <div class="row">
                     <div class="col-md-8 col-md-push-2" >
                         <h2 class="text-center">REPORTING BUGS</h2>
-                        <p class="customParagraphStyle">Bugs can be reported in the <a href="https://bugs.sugarlabs.org/newticket?component=Turtleart" class="hrefCustomColor">Sugar Labs bug tracker</a> or in the <a href="https://github.com/walterbender/turtleblocksjs/issues" class="hrefCustomColor">issues section</a> of this repository.</p>
+                        <p class="customParagraphStyle">Bugs can be reported in the <a href="https://bugs.sugarlabs.org/newticket?component=Turtleart" class="hrefCustomColor">Sugar Labs bug tracker</a> or in the <a href="https://github.com/sugarlabs/turtleblocksjs/issues" class="hrefCustomColor">issues section</a> of this repository.</p>
                     </div>
                 </div>
             </div>
@@ -118,7 +118,7 @@ permalink: /turtle-blocks-js/index.html
                 <div class="row">
                     <div class="col-md-8 col-md-push-2" >
                         <h2>ADVANCED FEATURES</h2>
-                        <p class="customFontSize">Turtle Blocks has a plugin mechanism that is used to add new blocks. You can learn more about how to use plugins (and how to write them) from the <a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/README.md" class="hrefCustomColor">Plugins Guide</a>.</p>
+                        <p class="customFontSize">Turtle Blocks has a plugin mechanism that is used to add new blocks. You can learn more about how to use plugins (and how to write them) from the <a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/README.md" class="hrefCustomColor">Plugins Guide</a>.</p>
                         <br>
                     </div>
                 </div>
@@ -139,20 +139,20 @@ permalink: /turtle-blocks-js/index.html
                             <hr>
                             <ul class="listDiscStyle">
                                <li class="listFont"><a href="https://github.com/SAMdroid-apps/turtlestorm" class="hrefCustomColor">Mindstorms</a>: blocks to interact with the LEGO Mindstorms robotics kit</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/rodi.json" class="hrefCustomColor">RoDi</a>: blocks to interact with RoDi wireless robot</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/maths.json" class="hrefCustomColor">Maths</a>: addition blocks for some more advanced mathematics</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/translate.json" class="hrefCustomColor">Translate</a>: blocks for translating strings between languages, e.g., English to Spanish</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/dictionary.json" class="hrefCustomColor">Dictionary</a>: a block to look up dictionary definitions</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/weather.json" class="hrefCustomColor">Weather</a>: blocks to retrieve global weather forecasts</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/logic.json" class="hrefCustomColor">Logic</a>: blocks for bitwise Boolean operations</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/finance.json" class="hrefCustomColor">Finance</a>: a block for looking up market prices</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/bitcoin.json" class="hrefCustomColor">Bitcoin</a>: a block for looking up bitcoin exchange rates</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/nutrition.json" class="hrefCustomColor">Nutrition</a>: blocks for exploring the nutritional content of food</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/facebook.json" class="hrefCustomColor">Facebook</a>: a block for publishing a project to Facebook</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/heap.json" class="hrefCustomColor">Heap</a>: blocks to support a heap and for loading and saving data</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/accelerometer.json" class="hrefCustomColor">Accelerometer</a>: blocks for accessing an accelerometer</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/turtle.json" class="hrefCustomColor">Turtle</a>: blocks to support advanced features when using multiple turtles</li>
-                                <li class="listFont"><a href="https://github.com/walterbender/turtleblocksjs/blob/master/plugins/gmap.json" class="hrefCustomColor">Gmap</a>: blocks to support generation of Google maps.</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/rodi.json" class="hrefCustomColor">RoDi</a>: blocks to interact with RoDi wireless robot</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/maths.json" class="hrefCustomColor">Maths</a>: addition blocks for some more advanced mathematics</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/translate.json" class="hrefCustomColor">Translate</a>: blocks for translating strings between languages, e.g., English to Spanish</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/dictionary.json" class="hrefCustomColor">Dictionary</a>: a block to look up dictionary definitions</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/weather.json" class="hrefCustomColor">Weather</a>: blocks to retrieve global weather forecasts</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/logic.json" class="hrefCustomColor">Logic</a>: blocks for bitwise Boolean operations</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/finance.json" class="hrefCustomColor">Finance</a>: a block for looking up market prices</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/bitcoin.json" class="hrefCustomColor">Bitcoin</a>: a block for looking up bitcoin exchange rates</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/nutrition.json" class="hrefCustomColor">Nutrition</a>: blocks for exploring the nutritional content of food</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/facebook.json" class="hrefCustomColor">Facebook</a>: a block for publishing a project to Facebook</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/heap.json" class="hrefCustomColor">Heap</a>: blocks to support a heap and for loading and saving data</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/accelerometer.json" class="hrefCustomColor">Accelerometer</a>: blocks for accessing an accelerometer</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/turtle.json" class="hrefCustomColor">Turtle</a>: blocks to support advanced features when using multiple turtles</li>
+                                <li class="listFont"><a href="https://github.com/sugarlabs/turtleblocksjs/blob/master/plugins/gmap.json" class="hrefCustomColor">Gmap</a>: blocks to support generation of Google maps.</li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
I have updated all TB and MB links which previously used to point to Walter's github repo - they now point to the respective sugarlabs repos.

I updated MB's description re contributions made by GCI and GSoC participants (I got this new data from https://github.com/sugarlabs/musicblocks/blob/master/README.md)

I also realised that Dr Larry Scripp's NEC link was deprecated and replaced it with what I presume to be an updated page of his [here](https://necmusic.edu/faculty/larry-scripp)