### PR TITLE
Changes in 'About Us' headign on about us page.

### DIFF
--- a/css/airspace.css
+++ b/css/airspace.css
@@ -2229,6 +2229,7 @@ h1:before {
 
 .tag-regular {
   background-color: #fff;
+  padding-top: 2.7px;
   border: 1px solid #ddd;
   color: #000000;
   font-size:30px;


### PR DESCRIPTION
The 'About Us' heading heading on the about us page is not vertically aligned properly inside the box, so giving a padding-top has resolved the issue. I have made the necessary changes in the code and now the heading looks fine.