### PR TITLE
Fixed the overlapping of 'footer icons'

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -57,24 +57,19 @@
                         </article>
                     </div>
                     <div class="col-md-6">
-                        <div class="row">
-                            <div class="col-md-12" >
-                                <br>
-                                <div class="justify-content-center">
-                                    <div class="row d-flex justify-content-center">
-                                        <div id="own-ssk" class="ssk-group d-flex">
-                                            <a href="https://www.facebook.com/SugarLabs-187845102582/timeline/" class="ion-icon ion-logo-facebook"></a>
-                                            <a href="https://github.com/sugarlabs" class="ion-icon ion-logo-github"></a>
-                                            <a href="https://twitter.com/sugar_labs" class="ion-icon ion-logo-twitter"></a>
-                                            <a href="https://www.instagram.com/sugarlabsforall/" class="ion-icon ion-logo-instagram" ></a>
-                                            <a href="https://www.youtube.com/channel/UCfsR9AEb7HuPRAc14jfiI6g/featured" class="ion-icon ion-logo-youtube"></a>
-                                        </div>
-                                    </div>
-                                    <br>
-                                    <div id="contributeHeader" class="col-md-12">
-                                        <h4 class='align-center-md'><a href="https://github.com/sugarlabs/www-sugarlabs"><b><span class="ion-logo-github" style="font-size:17px;color: #0099FF; margin-right: 12px;"></span><span style="font-size:17px;color: #0099FF;">Contribute to website</span></b></a></h4>
-                                    </div>
+                        <div class="row justify-content-center">
+                            <div class="row d-flex justify-content-center">
+                                <div id="own-ssk" class="ssk-group d-flex">
+                                    <a href="https://www.facebook.com/SugarLabs-187845102582/timeline/" class="ion-icon ion-logo-facebook"></a>
+                                    <a href="https://github.com/sugarlabs" class="ion-icon ion-logo-github"></a>
+                                    <a href="https://twitter.com/sugar_labs" class="ion-icon ion-logo-twitter"></a>
+                                    <a href="https://www.instagram.com/sugarlabsforall/" class="ion-icon ion-logo-instagram" ></a>
+                                    <a href="https://www.youtube.com/channel/UCfsR9AEb7HuPRAc14jfiI6g/featured" class="ion-icon ion-logo-youtube"></a>
                                 </div>
+                            </div>
+                            <br>
+                            <div id="contributeHeader" class="col-md-12">
+                                <h4 class="text-center"><a href="https://github.com/sugarlabs/www-sugarlabs"><b><span class="ion-logo-github" style="font-size:17px;color: #0099FF; margin-right: 12px;"></span><span style="font-size:17px;color: #0099FF;">Contribute to website</span></b></a></h4>
                             </div>
                         </div>
                     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -77,7 +77,7 @@
                 </br>
                 <div class="row" >
                     <div class="col-md-12" style="margin-top:12px;">
-                        <p style="text-align:left;font-size:13px;" class='text-center-md'>
+                        <p style="font-size:13px;" class='text-center-md'>
                         Copyright &copy; 2017 Sugar Labs&reg; available under the <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License(CC-BY-SA)</a>.</br>
                         Website base template: Designed and developed by Themefisher
                         </p>

--- a/css/airspace.css
+++ b/css/airspace.css
@@ -952,9 +952,6 @@ footer .footer-manu ul li a:hover {
     .active.widget h4:after {
         background:#ccc;
     }
-    .ssk-group{
-      position: absolute;
-    }
 }
 #own-ssk{
   margin-left: 5px;


### PR DESCRIPTION
Fixes: #370 
As shown below:

* removed the 'position' style of footer icons in 'airspace.css' to stop overlapping.

* made footer div responsive by correcting classes in 'footer.html' icons div and aligned code lines correctly after the change (as div are removed).


![enhanced](https://user-images.githubusercontent.com/86892991/152647316-4e0ca5e0-ea4f-443f-9584-09c36664e1dc.png)

