### PR TITLE
Fix search bar overlapping title. Fixes #375

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.15.0)
     multipart-post (2.1.1)
+    nokogiri (1.13.8-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -268,13 +270,16 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     zeitwerk (2.5.3)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
   github-pages
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.2.22

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,6 +15,7 @@
             if(expanded){
             event.stopPropagation();}
         });
+        
         var searchbar = $("#searchForm").offset();
         var menubar = $("#menuBar").offset();var distance1 = menubar.left -(searchbar.left + 200);
         if((searchbar.left +200)>menubar.left){
@@ -28,11 +29,11 @@
             var menubar = $("#menuBar").offset();
             var distance1 = menubar.left -(searchbar.left + 200) ;
             if((searchbar.left +200)>menubar.left){
-                var distance= distance1 + 13 + searchbar.left;
-                $("#searchForm").css("left", distance.toString() + "px");
+                $("#searchForm").css("left", "25.2%");
             }else if(distance1>39){
                 var distance =searchbar.left +  distance1 - 39;
-                $("#searchForm").css("left", distance.toString() + "px");}
+                $("#searchForm").css("left", distance.toString() + "px");
+            }
             }
         );
     });

--- a/css/airspace.css
+++ b/css/airspace.css
@@ -7,7 +7,7 @@
   position:absolute;
   left:350px;
   z-index:2;
-  width: 200px;
+  width: 180px;
   box-sizing: border-box;
   border: 2px solid #ccc;
   border-radius: 4px;


### PR DESCRIPTION
1. In files Gemfile and Gemfile.lock, `webrick` dependency is added to avoid the 'require' error.

2. In `nav.html` file, the left CSS property is set to be a relative value of 25.2% to avoid overlapping with title and distance variable is removed wherever necessary.

3. In `airspace.css`, width of `searchForm` is reduced to 180px to resolve the issue of overlapping.